### PR TITLE
add missing handling of system_server restarts

### DIFF
--- a/logd/LogReaderList.cpp
+++ b/logd/LogReaderList.cpp
@@ -31,7 +31,7 @@ static sp<ILogcatManagerService> InitLogcatService() {
 }
 
 static sp<ILogcatManagerService> GetLogcatService() {
-    static sp<ILogcatManagerService> logcat_service = InitLogcatService();
+    sp<ILogcatManagerService> logcat_service = InitLogcatService();
 
     if (logcat_service == nullptr) {
         LOG(ERROR) << "Permission problem or fatal error occurs to get logcat service";


### PR DESCRIPTION
LogcatManagerService is hosted by system_server and reference to it becomes dangling after system_server restarts.

This issue led to logcat viewer being broken in LogViewer app after system_server crash until full device reboot.

15: https://github.com/GrapheneOS/platform_system_logging/pull/3