### PR TITLE
increase log buffer size from 256 KiB to 512 KiB

### DIFF
--- a/logd/LogSize.h
+++ b/logd/LogSize.h
@@ -20,7 +20,7 @@
 
 #include <log/log.h>
 
-static constexpr size_t kDefaultLogBufferSize = 256 * 1024;
+static constexpr size_t kDefaultLogBufferSize = 512 * 1024;
 static constexpr size_t kLogBufferMinSize = 64 * 1024;
 static constexpr size_t kLogBufferMaxSize = 256 * 1024 * 1024;
 


### PR DESCRIPTION
The default size is too small, which often leads to decreased usefulness of user-submitted logs.